### PR TITLE
Tid fix domain name

### DIFF
--- a/capif.py
+++ b/capif.py
@@ -54,12 +54,12 @@ class CapifHandler:
                     for line in template:
                         if _interface_or_domain_name in line:
                             if cls.frontEndDomainName != None:
-                                output.write('                     "domainName:"' + cls.frontEndDomainName)
+                                output.write('                     "domainName": "' + cls.frontEndDomainName + '"')
                             if cls.frontEndHost != None and cls.frontEndPort != None:
                                 output.write('                     "interfaceDescriptions": [')
                                 output.write('                       {')
-                                output.write('                         "ipv4Addr": ' + str(cls.frontEndHost) + ',')
-                                output.write('                         "port": ' + str(cls.frontEndPort) + ',')
+                                output.write('                         "ipv4Addr": "' + str(cls.frontEndHost) + '",')
+                                output.write('                         "port": "' + str(cls.frontEndPort) + '",')
                                 output.write('                         "securityMethods": ["OAUTH"]')
                                 output.write('                       }')
                                 output.write('                     ]')

--- a/capif.py
+++ b/capif.py
@@ -63,6 +63,8 @@ class CapifHandler:
                                 output.write('                         "securityMethods": ["OAUTH"]')
                                 output.write('                       }')
                                 output.write('                     ]')
+                        else:
+                            output.write(line
                         # output.write(line
                         #              .replace('<<HOST>>', f'"{cls.frontEndHost}"')
                         #              .replace('<<PORT>>', str(cls.frontEndPort)))

--- a/capif.py
+++ b/capif.py
@@ -12,7 +12,7 @@ class CapifHandler:
     _interface_or_domain_name = '<<INTERFACE_OR_DOMAIN_NAME>>'
 
     initialized = False
-    frontEndHost = frontEndPort = None
+    frontEndHost = frontEndPort = frontEndDomainName =None
     host = httpPort = httpsPort = None
     securityEnabled = loggingEnabled = None
 
@@ -52,7 +52,7 @@ class CapifHandler:
             with open(join(cls.baseFolder, 'tsn_af_api.Template'), 'r', encoding='utf-8') as template:
                 with open(join(cls.baseFolder, 'tsn_af_api.json'), 'w', encoding='utf-8') as output:
                     for line in template:
-                        if _interface_or_domain_name in line:
+                        if cls._interface_or_domain_name in line:
                             if cls.frontEndDomainName != None:
                                 output.write('                     "domainName": "' + cls.frontEndDomainName + '"')
                             if cls.frontEndHost != None and cls.frontEndPort != None:

--- a/capif.py
+++ b/capif.py
@@ -64,7 +64,7 @@ class CapifHandler:
                                 output.write('                       }')
                                 output.write('                     ]')
                         else:
-                            output.write(line
+                            output.write(line)
                         # output.write(line
                         #              .replace('<<HOST>>', f'"{cls.frontEndHost}"')
                         #              .replace('<<PORT>>', str(cls.frontEndPort)))

--- a/capif.py
+++ b/capif.py
@@ -5,6 +5,7 @@ from string import ascii_letters
 from requests.exceptions import RequestException
 from typing import Dict
 
+
 class CapifHandler:
     detailsFile = './capif_data/publisherDetails.txt'
     baseFolder = abspath(join(dirname(__file__), 'capif_data'))
@@ -12,7 +13,7 @@ class CapifHandler:
     _interface_or_domain_name = '<<INTERFACE_OR_DOMAIN_NAME>>'
 
     initialized = False
-    frontEndHost = frontEndPort = frontEndDomainName =None
+    frontEndHost = frontEndPort = frontEndDomainName = None
     host = httpPort = httpsPort = None
     securityEnabled = loggingEnabled = None
 
@@ -23,7 +24,7 @@ class CapifHandler:
         cls.frontEndDomainName = None
         cls.frontEndHost = None
         cls.frontEndPort = None
-        if config['FrontEnd'].get('DomainName',None) != None:
+        if config['FrontEnd'].get('DomainName', None) is not None:
             cls.frontEndDomainName = config['FrontEnd']['DomainName']
         else:
             cls.frontEndHost = config['FrontEnd']['Host']
@@ -53,21 +54,18 @@ class CapifHandler:
                 with open(join(cls.baseFolder, 'tsn_af_api.json'), 'w', encoding='utf-8') as output:
                     for line in template:
                         if cls._interface_or_domain_name in line:
-                            if cls.frontEndDomainName != None:
-                                output.write('                     "domainName": "' + cls.frontEndDomainName + '"')
-                            if cls.frontEndHost != None and cls.frontEndPort != None:
+                            if cls.frontEndDomainName is not None:
+                                output.write(f'                     "domainName": "{cls.frontEndDomainName}"')
+                            if cls.frontEndHost is not None and cls.frontEndPort is not None:
                                 output.write('                     "interfaceDescriptions": [')
                                 output.write('                       {')
-                                output.write('                         "ipv4Addr": "' + str(cls.frontEndHost) + '",')
-                                output.write('                         "port": "' + str(cls.frontEndPort) + '",')
+                                output.write(f'                         "ipv4Addr": "{cls.frontEndHost}",')
+                                output.write(f'                         "port": "{cls.frontEndPort}",')
                                 output.write('                         "securityMethods": ["OAUTH"]')
                                 output.write('                       }')
                                 output.write('                     ]')
                         else:
                             output.write(line)
-                        # output.write(line
-                        #              .replace('<<HOST>>', f'"{cls.frontEndHost}"')
-                        #              .replace('<<PORT>>', str(cls.frontEndPort)))
 
             capif_connector = CAPIFProviderConnector(certificates_folder=cls.baseFolder,
                                                      capif_host=cls.host,

--- a/capif_data/tsn_af_api.Template
+++ b/capif_data/tsn_af_api.Template
@@ -56,13 +56,7 @@
         "protocol": "HTTP_1_1",
         "dataFormat": "JSON",
         "securityMethods": ["OAUTH"],
-        "interfaceDescriptions": [
-          {
-            "ipv4Addr": <<HOST>>,
-            "port": <<PORT>>,
-            "securityMethods": ["OAUTH"]
-          }
-        ]
+        <<INTERFACE_OR_DOMAIN_NAME>>
       }
     ],
     "description": "API of dummy netapp to test",


### PR DESCRIPTION
This only an example of how to setup domainName instead of interfaceDescriptions at registration on capif.

This code solve the issue we found on testing that we must use DomainName parameter on AEF publication becasue on k8s environment we need to setup host name and port to access instead ip and port.